### PR TITLE
Code Minor fixes

### DIFF
--- a/params/basic_params.py
+++ b/params/basic_params.py
@@ -203,7 +203,8 @@ class BasicParams:
             if int_gpu_id >= 0:
                 param.gpu_ids.append(int_gpu_id)
         if len(param.gpu_ids) > 0:
-            torch.cuda.set_device(param.gpu_ids[0])
+            torch.cuda.device(param.gpu_ids[0]) #usage of this function is discouraged in favor of torch.cuda.device(device)
+            #https://pytorch.org/docs/stable/generated/torch.cuda.set_device.html
 
         self.param = param
         return self.param

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ tensorboard>=1.10.0
 prefetch_generator>=1.0.0
 tables>=3.6.0
 scikit-survival>=0.6.0
+
+GPU/graphics card is one of those listed to run PyTorch with CUDA 
+https://en.wikipedia.org/wiki/CUDA#GPUs_supported


### PR DESCRIPTION
Modified code at _206_ of _basic_params.py_ as usage of `torch.cud.set_device(device)` is discouraged in favor of `torch.cuda.device(device)` 
https://pytorch.org/docs/stable/generated/torch.cuda.set_device.html

Minor fix to the `requirements.txt` doc. _PyTorch CUDA_ wont run if the graphics card isn't listed as one of those
https://en.wikipedia.org/wiki/CUDA#GPUs_supported